### PR TITLE
PLATUI-2891: disable media router by default

### DIFF
--- a/browser-versions.toml
+++ b/browser-versions.toml
@@ -8,7 +8,7 @@ selenium-manager = true
 
 [[node.driver-configuration]]
 display-name = "Chrome"
-stereotype = '{"browserName": "chrome", "browserVersion": "120"}'
+stereotype = '{"browserName": "chrome", "browserVersion": "120", "goog:chromeOptions": {"args": ["--disable-features=MediaRouter"]}}'
 
 [[node.driver-configuration]]
 display-name = "Firefox"


### PR DESCRIPTION
This will stop firewall prompts on macs when the browser opens asking you to allow/deny incoming network connections

For some reason macs can get in a funny state where clicking allow removes any existing allow rule from the firewall allowlist and doesn't persist the new "allow" grant

Got the fix from [similar issue people experience with puppeteer](https://github.com/puppeteer/puppeteer/issues/4752#issuecomment-1228060293)